### PR TITLE
Freeloader rename

### DIFF
--- a/templates/catalog.jinja
+++ b/templates/catalog.jinja
@@ -6,6 +6,19 @@
       Enjoy the power of the Wild Apricot API.
     </p>
 
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <ul>
+      {% for message in messages %}
+        <li>{{ message }}</li>
+      {% endfor %}
+      </ul>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endif %}
+  {% endwith %}
+
   <div class="mb-5"></div>
 
   <div class="card">  
@@ -21,11 +34,12 @@
   </div>
   <div class="card">  
   <div class="card-body">
-    <h5 class="card-title">Slack freeloaders</h5>
-    <form action="{{ url_for('reports.report_slackfreeloaders') }}" method="POST" enctype="multipart/form-data">
+    <h5 class="card-title">Slack orphans</h5>
+    <form action="{{ url_for('reports.report_slack_orphans') }}" method="POST" enctype="multipart/form-data">
     <p class="card-text">Shows folks with e-mails that appear in Slack, but are not active or pending members, or alumni.
-    To use this, you must have a CSV file exported from Slack. Required columns are Slack username, email, fullname, status.</p>
-    <input type="file" name="file">
+    To use this, you must have a CSV file exported from Slack. Required columns, with a header row, are Slack 
+    username, email, fullname, status.</p>
+    <input type="file" name="file" accept=".csv">
     <button type="submit" class="btn btn-primary">Get report</button>
     </form>
   </div>

--- a/templates/report/slack_orphans.jinja
+++ b/templates/report/slack_orphans.jinja
@@ -1,9 +1,9 @@
 {% extends "base.jinja" %}
-{% block title %}Slack Freeloaders{% endblock %}
+{% block title %}Slack Orphans{% endblock %}
 {% block content %}
-<div class="mb-5"><h1>Slack Freeloaders</h1></div>
+<div class="mb-5"><h1>Slack Orphans</h1></div>
 <p>There are {{ num_membership_emails}} valid member emails. Those below don't have one of them!
-{{ num_freeloaders }} freeloaders found.</p>
+{{ num_orphans }} orphans found.</p>
 
 <table class="table table-striped table-bordered">
 <thead>
@@ -14,11 +14,11 @@
   </tr>
 </thead>
 <tbody>
-{% for freeloader in freeloaders %}
+{% for orphan in orphans %}
   <tr>
-    <td>{{ freeloader.username }}</td>
-    <td>{{ freeloader.fullname }}</td>
-    <td>{{ freeloader.email }}</td>
+    <td>{{ orphan.username }}</td>
+    <td>{{ orphan.fullname }}</td>
+    <td>{{ orphan.email }}</td>
   </tr>
 {% endfor %}
 </tbody>

--- a/wareporting.py
+++ b/wareporting.py
@@ -25,6 +25,7 @@ app.secret_key = os.environ['WA_REPORTING_FLASK_SECRET_KEY']
 # flask_executor plugin configuration
 app.config['EXECUTOR_TYPE'] = 'thread'
 app.config['ALLOW_LOCALHOST'] = False
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1000 * 1000 # 16 MB max file upload size
 
 if __name__ == "__main__":
     # This code will only run if you run this file directly. It will not run


### PR DESCRIPTION
Rename Slack freeloaders to Slack orphans.
Make some nicer error handling and add more checks for the integrity of the uploaded Slack file up front.