### PR TITLE
Handle pagination for Wild Apricot API calls

### DIFF
--- a/wadata.py
+++ b/wadata.py
@@ -85,6 +85,12 @@ def call_api(
                 if isinstance(value, list):
                     list_key = key
                     break
+            if list_key is None:
+                # No list found; return the original response without pagination
+                logger.debug(
+                    "Response contained no list; returning raw JSON without pagination"
+                )
+                return data
 
         if list_key is not None and isinstance(data, dict):
             page_items = data.get(list_key, [])


### PR DESCRIPTION
## Summary
- guard pagination and return raw JSON when the first page contains no list

## Testing
- `python -m py_compile wadata.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b35f10e08328928b4cba7d19033f